### PR TITLE
fix: php iconv invalid

### DIFF
--- a/Dockerfile.cn
+++ b/Dockerfile.cn
@@ -1,11 +1,13 @@
-FROM php:7.4.26-alpine3.14
+FROM php:7.4.26-alpine3.13
 
 
 MAINTAINER jani <liberty_linlin@qq.com>
 
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
-    && apk update && apk upgrade
+    && apk update && apk upgrade \
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 
 WORKDIR /app/


### PR DESCRIPTION
## iconv 无法正常使用

错误关联
- [php alpine libiconv 中文编码错误](https://github.com/HenryQW/Awesome-TTRSS/issues/98)
- [gnu-libiconv 1.16-r0 不存在 preloadable_libiconv.so 文件](https://gitlab.alpinelinux.org/alpine/aports/-/issues/12328)
- [Alpine 3.13 使用 iconv](https://github.com/docker-library/php/issues/1121)
